### PR TITLE
Fix: Add option to disable for touch devices (fixes #4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ An extension to inspect details of elements.
 * Add the following to `config.json`:
 ```json
 "_inspector": {
-	"_isEnabled": true
+  "_isEnabled": true
 }
 ```
 * Optionally, reference the [example JSON](example.json) to make Inspector link to a specific [Trac](https://trac.edgewall.org) or to disable Inspector on touch devices.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ An extension to inspect details of elements.
 	"_isEnabled": true
 }
 ```
-* Optionally, reference the [example JSON](example.json) to make Inspector link to a specific [Trac](https://trac.edgewall.org).
+* Optionally, reference the [example JSON](example.json) to make Inspector link to a specific [Trac](https://trac.edgewall.org) or to disable Inspector on touch devices.
 * With [Adapt CLI](https://github.com/adaptlearning/adapt-cli) installed, run `adapt install inspector`. Alternatively, download the ZIP and extract into the src > extensions directory.
 * Run an appropriate Grunt task.
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ An extension to inspect details of elements.
 		<td><code>false</code></td>
 	</tr>
 	<tr>
+		<td colspan="2"><code>_disableOnTouch</code></td>
+		<td>Boolean</td>
+		<td>Disable Inspector on touch devices</td>
+		<td><code>true</code></td>
+	</tr>
+	<tr>
 		<td rowspan="3"><code>_trac</code></td>
 		<td><code>_isEnabled</code></td>
 		<td>Boolean</td>

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ An extension to inspect details of elements.
 		<td><code>false</code></td>
 	</tr>
 	<tr>
-		<td colspan="2"><code>_disableOnTouch</code></td>
+		<td colspan="2"><code>_isDisabledOnTouch</code></td>
 		<td>Boolean</td>
 		<td>Disable Inspector on touch devices</td>
 		<td><code>true</code></td>

--- a/example.json
+++ b/example.json
@@ -1,5 +1,6 @@
 "_inspector": {
 	"_isEnabled": true,
+	"_disableOnTouch": true,
 	"_trac": {
 		"_isEnabled": false,
 		"_url": "",

--- a/example.json
+++ b/example.json
@@ -1,6 +1,6 @@
 "_inspector": {
 	"_isEnabled": true,
-	"_disableOnTouch": true,
+	"_isDisabledOnTouch": true,
 	"_trac": {
 		"_isEnabled": false,
 		"_url": "",

--- a/js/adapt-inspector.js
+++ b/js/adapt-inspector.js
@@ -1,4 +1,7 @@
-define([ 'core/js/adapt' ], function(Adapt) {
+define([
+  'core/js/adapt',
+  'core/js/device'
+], function(Adapt, device) {
 
   const InspectorView = Backbone.View.extend({
 
@@ -7,6 +10,9 @@ define([ 'core/js/adapt' ], function(Adapt) {
     ids: [],
 
     initialize: function() {
+      const config = Adapt.config.get('_inspector');
+      if (device.touch && config._isDisabledOnTouch) return;
+
       this.listenTo(Adapt, {
         'inspector:id': this.pushId,
         'inspector:hover': this.setVisibility,

--- a/properties.schema
+++ b/properties.schema
@@ -30,7 +30,7 @@
                       "title": "Link Inspector to Trac",
                       "inputType": "Checkbox"
                     },
-                    "_disableOnTouch": {
+                    "_isDisabledOnTouch": {
                       "type": "boolean",
                       "default": true,
                       "title": "Disable Inspector on touch devices",

--- a/properties.schema
+++ b/properties.schema
@@ -30,6 +30,12 @@
                       "title": "Link Inspector to Trac",
                       "inputType": "Checkbox"
                     },
+                    "_disableOnTouch": {
+                      "type": "boolean",
+                      "default": true,
+                      "title": "Disable Inspector on touch devices",
+                      "inputType": "Checkbox"
+                    },
                     "_url": {
                       "type": "string",
                       "default": "",

--- a/properties.schema
+++ b/properties.schema
@@ -20,6 +20,12 @@
                   "inputType": "Checkbox",
                   "help": "Adds visible element IDs on hover. Also useful for Kineo employees with internal access to file issues in TRAC."
                 },
+                "_isDisabledOnTouch": {
+                  "type": "boolean",
+                  "default": true,
+                  "title": "Disable Inspector on touch devices",
+                  "inputType": "Checkbox"
+                },
                 "_trac": {
                   "type": "object",
                   "title": "Trac",
@@ -28,12 +34,6 @@
                       "type": "boolean",
                       "default": false,
                       "title": "Link Inspector to Trac",
-                      "inputType": "Checkbox"
-                    },
-                    "_isDisabledOnTouch": {
-                      "type": "boolean",
-                      "default": true,
-                      "title": "Disable Inspector on touch devices",
                       "inputType": "Checkbox"
                     },
                     "_url": {

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -29,7 +29,7 @@
                   "title": "Link Inspector to Trac",
                   "default": false
                 },
-                "_disableOnTouch": {
+                "_isDisabledOnTouch": {
                   "type": "boolean",
                   "title": "Disable Inspector on touch devices",
                   "default": true

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -19,6 +19,11 @@
               "description": "Adds visible element IDs on hover. Also useful for Kineo employees with internal access to file issues in TRAC.",
               "default": false
             },
+            "_isDisabledOnTouch": {
+              "type": "boolean",
+              "title": "Disable Inspector on touch devices",
+              "default": true
+            },
             "_trac": {
               "type": "object",
               "title": "Trac",
@@ -28,11 +33,6 @@
                   "type": "boolean",
                   "title": "Link Inspector to Trac",
                   "default": false
-                },
-                "_isDisabledOnTouch": {
-                  "type": "boolean",
-                  "title": "Disable Inspector on touch devices",
-                  "default": true
                 },
                 "_url": {
                   "type": "string",

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -29,6 +29,11 @@
                   "title": "Link Inspector to Trac",
                   "default": false
                 },
+                "_disableOnTouch": {
+                  "type": "boolean",
+                  "title": "Disable Inspector on touch devices",
+                  "default": true
+                },
                 "_url": {
                   "type": "string",
                   "title": "URL",


### PR DESCRIPTION
Fix #4 

### Fix
* Adds new property `_isDisabledOnTouch`

### Testing
Add this to _config.json_:
```
  "_inspector": {
    "_isEnabled": true,
    "_isDisabledOnTouch": true
  },
```
Then, test on a mobile device and ensure that Inspector is disabled.