### PR TITLE
New: Add _quizBankID to block hover (fixes #9)

### DIFF
--- a/templates/inspector.hbs
+++ b/templates/inspector.hbs
@@ -4,8 +4,8 @@
 {{/if}}{{#if _classes}}Classes: {{_classes}}
 {{/if}}{{#if _layout}}Layout: {{_layout}}
 {{/if}}Title: {{#if title}}{{title}}{{else}}<none>{{/if}}
-Optional: {{#if _isOptional}}Yes{{else}}No{{/if}}
-{{#if _assessment}}{{#if _assessment._quizBankID}}Question Bank: {{_assessment._quizBankID}}{{/if}}{{/if}}{{#if _selectable}}
+Optional: {{#if _isOptional}}Yes{{else}}No{{/if}}{{#if _assessment}}{{#if _assessment._quizBankID}}
+Question Bank: {{_assessment._quizBankID}}{{/if}}{{/if}}{{#if _selectable}}
 Correct:{{#if _children.models}}{{#each _children.models}}{{#if attributes._shouldBeSelected}} {{numbers @index}}{{/if}}{{/each}}{{else}}{{#each _items}}{{#if _shouldBeSelected}} {{numbers @index}}{{/if}}{{/each}}{{/if}}{{/if}}{{#if_value_equals _component "matching"}}
 Correct:{{#each _items}}{{#if ../_items.[1]}}
 {{numbers @index}}.{{/if}}{{#each _options}}{{#if _isCorrect}} {{text}}{{/if}}{{/each}}{{/each}}{{/if_value_equals}}{{#if_value_equals _component "slider"}}

--- a/templates/inspector.hbs
+++ b/templates/inspector.hbs
@@ -4,7 +4,8 @@
 {{/if}}{{#if _classes}}Classes: {{_classes}}
 {{/if}}{{#if _layout}}Layout: {{_layout}}
 {{/if}}Title: {{#if title}}{{title}}{{else}}<none>{{/if}}
-Optional: {{#if _isOptional}}Yes{{else}}No{{/if}}{{#if _selectable}}
+Optional: {{#if _isOptional}}Yes{{else}}No{{/if}}
+{{#if _assessment}}{{#if _assessment._quizBankID}}Question Bank: {{_assessment._quizBankID}}{{/if}}{{/if}}{{#if _selectable}}
 Correct:{{#if _children.models}}{{#each _children.models}}{{#if attributes._shouldBeSelected}} {{numbers @index}}{{/if}}{{/each}}{{else}}{{#each _items}}{{#if _shouldBeSelected}} {{numbers @index}}{{/if}}{{/each}}{{/if}}{{/if}}{{#if_value_equals _component "matching"}}
 Correct:{{#each _items}}{{#if ../_items.[1]}}
 {{numbers @index}}.{{/if}}{{#each _options}}{{#if _isCorrect}} {{text}}{{/if}}{{/each}}{{/each}}{{/if_value_equals}}{{#if_value_equals _component "slider"}}


### PR DESCRIPTION
Fix #9 

### Fix
* Add `_quizBankID` to block hover.

### Testing
1. Add a question bank ID to a block.

```
  {
    "_id": "b-410",
    "_parentId": "a-410",
    "_type": "block",
    "_classes": "",
    "title": "",
    "displayTitle": "",
    "body": "",
    "_assessment": {
      "_quizBankID": 1
    },
```
2. Hover over the block to view additional information. You should see the bank ID.

![bank](https://github.com/user-attachments/assets/53846d77-7f9f-49da-871b-bf3e091c51f8)
